### PR TITLE
🔥 Remove club-specific branding, make app generic multi-club

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Archery Manager — GitHub Copilot Instructions
 
-**Archery Manager** is a Symfony 7.4 web application for managing an archery club (Les Archers de Bordeaux Guyenne, AGPL v3). It handles member management, event scheduling, FFTA federation synchronization, equipment tracking, club applications, and GDPR consent.
+**Archery Manager** is a Symfony 7.4 multi-club web application for managing archery clubs (AGPL v3). Originally built for Les Archers de Bordeaux Guyenne, it is designed to support multiple clubs. It handles member management, event scheduling, FFTA federation synchronization, equipment tracking, club applications, and GDPR consent.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Un outil de gestion pour les clubs de tir à l'arc
 - Gestion de l'équipement
 - Gestion des évènements : entraînements, compétitions, autre
 
-Cet outil est réalisé pour [Les Archers de Bordeaux Guyenne](https://archersdebordeaux-guyenne.com).
+Initialement réalisé pour [Les Archers de Bordeaux Guyenne](https://archersdebordeaux-guyenne.com), cet outil est conçu pour devenir un outil multi-clubs.
 
 ## Exécution locale
 

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -71,7 +71,7 @@ class RegistrationController extends AbstractController
                     ->from(
                         new Address(
                             'archerie@admds.net',
-                            "L'Archerie des Archers de Guyenne",
+                            'Archery Manager',
                         ),
                     )
                     ->to($user->getEmail())

--- a/src/Controller/ResetPasswordController.php
+++ b/src/Controller/ResetPasswordController.php
@@ -205,7 +205,7 @@ class ResetPasswordController extends AbstractController
         }
 
         $email = new TemplatedEmail()
-            ->from(new Address('noreply@admds.net', 'Les Archers de Guyenne'))
+            ->from(new Address('noreply@admds.net', 'Archery Manager'))
             ->to($user->getEmail())
             ->subject('Votre demande de réinitialisation de mot de passe')
             ->htmlTemplate('reset_password/email.html.twig')

--- a/src/Service/SecurityNotificationService.php
+++ b/src/Service/SecurityNotificationService.php
@@ -16,7 +16,7 @@ class SecurityNotificationService
 {
     private const string MAILER_FROM_EMAIL = 'noreply@admds.net';
 
-    private const string MAILER_FROM_NAME = 'Les Archers de Guyenne';
+    private const string MAILER_FROM_NAME = 'Archery Manager';
 
     public function __construct(
         private readonly MailerInterface $mailer,

--- a/templates/base_public.html.twig
+++ b/templates/base_public.html.twig
@@ -20,7 +20,7 @@
         {{ encore_entry_script_tags('public') }}
     {% endblock %}
 
-    <title>{% block title %}Les Archers de Bordeaux Guyenne{% endblock %}</title>
+    <title>{% block title %}Archery Manager{% endblock %}</title>
 </head>
 <body
     data-env-matomo-url="{{ matomoUrl ?? '' }}"

--- a/templates/base_unauthenticated.html.twig
+++ b/templates/base_unauthenticated.html.twig
@@ -31,7 +31,7 @@
         <div class="col-12 text-center mb-4">
             <a href="{{ path('app_login') }}">
                 <img src="{{ asset('build/logo.svg') }}"
-                     alt="Les Archers de Bordeaux Guyenne"
+                     alt="Logo"
                      style="max-width: 200px;"
                      class="mx-auto d-block"/>
             </a>

--- a/templates/email/account_locked.html.twig
+++ b/templates/email/account_locked.html.twig
@@ -52,5 +52,5 @@
 </p>
 
 <p style="color: #666; font-size: 12px;">
-    Cet email a été envoyé automatiquement par le système de sécurité des Archers de Bordeaux Guyenne.
+    Cet email a été envoyé automatiquement par le système de sécurité du club.
 </p>

--- a/templates/email/account_unlocked.html.twig
+++ b/templates/email/account_unlocked.html.twig
@@ -43,5 +43,5 @@
 </p>
 
 <p style="color: #666; font-size: 12px;">
-    Cet email a été envoyé automatiquement par le système de sécurité des Archers de Bordeaux Guyenne.
+    Cet email a été envoyé automatiquement par le système de sécurité du club.
 </p>

--- a/templates/email/security_warning.html.twig
+++ b/templates/email/security_warning.html.twig
@@ -38,5 +38,5 @@
 </p>
 
 <p style="color: #666; font-size: 12px; margin-top: 30px;">
-    Cet email a été envoyé automatiquement par le système de sécurité des Archers de Bordeaux Guyenne.
+    Cet email a été envoyé automatiquement par le système de sécurité du club.
 </p>

--- a/templates/email_base.html.twig
+++ b/templates/email_base.html.twig
@@ -52,25 +52,17 @@
                 <spacer size="16"></spacer>
                 <p class="text-center">{{ club.name }}<br/>
                     <a href="mailto:{{ club.contactEmail }}">{{ club.contactEmail }}</a></p>
+                {% if club.websiteUrl is defined and club.websiteUrl %}
                 <center>
                     <menu>
                         <item>
-                            <a href="https://www.facebook.com/LesArchersdeGuyenne/">
-                                <img src="{{ absolute_url(asset('build/facebook-square-brands.png')) }}" alt="Facebook">
-                            </a>
-                        </item>
-                        <item>
-                            <a href="https://www.instagram.com/archersdebordeaux/?hl=fr">
-                                <img src="{{ absolute_url(asset('build/instagram-square-brands.png')) }}" alt="Instagram">
-                            </a>
-                        </item>
-                        <item>
-                            <a href="https://www.archersdebordeaux-guyenne.com/">
+                            <a href="{{ club.websiteUrl }}">
                                 <img src="{{ absolute_url(asset('build/w-solid.png')) }}" alt="Site Internet">
                             </a>
                         </item>
                     </menu>
                 </center>
+                {% endif %}
             </columns>
         </row>
 

--- a/templates/licensee/mail_account_created.html.twig
+++ b/templates/licensee/mail_account_created.html.twig
@@ -11,7 +11,7 @@
 {% block content %}
     <row>
         <columns>
-            <p>Tout d'abord, je te souhaite au nom de toute l'équipe encadrante, la bienvenue aux Archers de Guyenne !
+            <p>Tout d'abord, je te souhaite au nom de toute l'équipe encadrante, la bienvenue au club !
                 Voici quelques petites informations complémentaires à ton inscription.</p>
 
             <h3>Discord</h3>
@@ -44,7 +44,7 @@
                 d'accéder à notre serveur privé en le copiant-collant quand l'application te le demandera :<br><br>
                 <strong>https://discord.gg/DmNs4MjbVw</strong></p>
 
-            <h3>L'application des Archers de Guyenne</h3>
+            <h3>L'application du club</h3>
 
             <p>Nous mettons également à disposition une application te permettant de :</p>
 

--- a/templates/login/index.html.twig
+++ b/templates/login/index.html.twig
@@ -14,7 +14,7 @@
     <div class="row justify-content-center align-content-center" style="min-height: 88vh">
         <div class="col-lg-4 col-sm-10">
             <img src="{{ asset('build/logo.svg') }}"
-                 alt="Les Archers de Bordeaux Guyenne"
+                 alt="Logo"
                  class="mx-auto d-block"/>
         </div>
         <div class="col-lg-6 col-sm-10">


### PR DESCRIPTION
## Summary

Removes all hardcoded references to "Les Archers de Bordeaux Guyenne" / "Les Archers de Guyenne" from the application, replacing them with generic labels to support the planned multi-club architecture.

Historical mentions are preserved in `README.md` and `.github/copilot-instructions.md` to document the project's origin.

## Changes

### Backend
- `src/Service/SecurityNotificationService.php` — `MAILER_FROM_NAME` → `'Archery Manager'`
- `src/Controller/ResetPasswordController.php` — email sender name → `'Archery Manager'`
- `src/Controller/RegistrationController.php` — email sender name → `'Archery Manager'`

### Templates
- `templates/base_public.html.twig` — page title → `Archery Manager`
- `templates/base_unauthenticated.html.twig` — logo `alt` → `Logo`
- `templates/login/index.html.twig` — logo `alt` → `Logo`
- `templates/email_base.html.twig` — removed hardcoded Facebook/Instagram/website social links; replaced with a conditional block using `club.websiteUrl`
- `templates/email/account_locked.html.twig` — "des Archers de Bordeaux Guyenne" → "du club"
- `templates/email/account_unlocked.html.twig` — same
- `templates/email/security_warning.html.twig` — same
- `templates/licensee/mail_account_created.html.twig` — "aux Archers de Guyenne" → "au club"; section title generified

### Documentation
- `README.md` — updated to note the app was originally built for Les Archers de Bordeaux Guyenne and is designed to become multi-club
- `.github/copilot-instructions.md` — updated opening sentence to reflect multi-club intent
