### PR TITLE
🐛 Fix ARCHERIE-4G admin user creation TypeError

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "sentry": {
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp"
+    }
+  }
+}

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -49,7 +49,7 @@ class UserCrudController extends AbstractCrudController
     {
         /** @var User $user */
         $user = parent::createEntity($entityFqcn);
-        $user->setPassword(Uuid::v4());
+        $user->setPassword(Uuid::v4()->toRfc4122());
         $user->setRoles(['ROLE_USER']);
 
         return $user;

--- a/tests/application/Controller/Admin/UserCrudControllerTest.php
+++ b/tests/application/Controller/Admin/UserCrudControllerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\application\Controller\Admin;
+
+use App\Controller\Admin\UserCrudController;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+final class UserCrudControllerTest extends TestCase
+{
+    public function testCreateEntitySetsStringPasswordAndDefaultRole(): void
+    {
+        $controller = new UserCrudController();
+
+        /** @var User $user */
+        $user = $controller->createEntity(User::class);
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertIsString($user->getPassword());
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i', $user->getPassword());
+        $this->assertContains('ROLE_USER', $user->getRoles());
+    }
+}


### PR DESCRIPTION
## Summary
- Fix Sentry issue [ARCHERIE-4G](https://flying-pingu.sentry.io/issues/7166014303/?project=6494146) caused by a type mismatch in admin user creation
- Convert generated UUID to RFC4122 string before setting user password in UserCrudController
- Add regression test for UserCrudController::createEntity password/role defaults
- Add local VS Code MCP configuration for Sentry in .vscode/mcp.json

## Sentry
- Issue: ARCHERIE-4G
- Error: TypeError in App\Entity\User::setPassword expecting ?string but receiving UuidV4

## Validation
- docker compose exec -u symfony -w /app app bin/phpunit tests/application/Controller/Admin/UserCrudControllerTest.php
- make qa
- docker compose exec -u symfony -w /app app bin/phpunit --exclude-group=disabled

## Commits
- 🐛 Fix admin user creation password type in UserCrudController
- ✨ Add Sentry MCP server configuration
