### PR TITLE
🐛 Add missing birthdate field to EasyAdmin User creation form

### DIFF
--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -13,6 +13,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\DateField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\EmailField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TelephoneField;
@@ -39,6 +40,7 @@ class UserCrudController extends AbstractCrudController
             TextField::new('firstname'),
             TextField::new('lastname'),
             EmailField::new('email'),
+            DateField::new('birthdate'),
             TelephoneField::new('phoneNumber'),
             AssociationField::new('licensees'),
         ];


### PR DESCRIPTION
## Summary

The EasyAdmin User creation/edit form was missing the `birthdate` field, which is a mandatory, non-nullable property on the `User` entity with `#[Assert\NotBlank]` and `#[Assert\LessThan('-15 years')]` validation constraints.

## Changes

- Added `DateField::new('birthdate')` to `UserCrudController::configureFields()`, positioned after the email field
- Added the corresponding `DateField` import

## Impact

Without this fix, creating a User via EasyAdmin would either fail Symfony validation (blank birthdate) or produce a database-level NOT NULL constraint violation.

> Note: `LicenseeCrudController` was not affected — it already included `birthdate`.
