### PR TITLE
🐛 Fix club_admin event edit: voter, nav link, and show page buttons

### DIFF
--- a/docker/build/image_build.sh
+++ b/docker/build/image_build.sh
@@ -11,7 +11,6 @@ apt-get install -y --no-install-recommends ca-certificates gnupg2
 
 mkdir -p /etc/apt/keyrings
 install -o root -g root -m 644 /docker/build/ondrej.gpg /etc/apt/keyrings/ondrej.gpg
-echo 'deb [signed-by=/etc/apt/keyrings/ondrej.gpg] https://ppa.launchpadcontent.net/ondrej/nginx/ubuntu noble main' | tee /etc/apt/sources.list.d/nginx.list
 echo 'deb [signed-by=/etc/apt/keyrings/ondrej.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble main' | tee /etc/apt/sources.list.d/php.list
 install -o root -g root -m 644 /docker/build/nodesource.gpg /etc/apt/keyrings/nodesource.gpg
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list

--- a/src/Controller/Management/EventManagementController.php
+++ b/src/Controller/Management/EventManagementController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller\Management;
 
 use App\DBAL\Types\EventType;
+use App\DBAL\Types\UserRoleType;
 use App\Entity\ContestEvent;
 use App\Entity\Event;
 use App\Entity\FreeTrainingEvent;
@@ -18,6 +19,7 @@ use App\Repository\EventRepository;
 use App\Security\Voter\EventVoter;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -29,6 +31,7 @@ class EventManagementController extends AbstractController
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly ClubHelper $clubHelper,
+        private readonly Security $security,
     ) {
     }
 
@@ -41,22 +44,23 @@ class EventManagementController extends AbstractController
         $page = max(1, $request->query->getInt('page', 1));
         $limit = 20;
         $offset = ($page - 1) * $limit;
+        $isFullAdmin = $this->security->isGranted(UserRoleType::ADMIN);
 
-        $events = $eventRepository->createQueryBuilder('e')
-            ->where('e.club = :club')
-            ->setParameter('club', $this->clubHelper->activeClub())
+        $listQb = $eventRepository->createQueryBuilder('e');
+        $countQb = $eventRepository->createQueryBuilder('e')->select('COUNT(e.id)');
+        if (!$isFullAdmin) {
+            $listQb->where('e.club = :club')->setParameter('club', $this->clubHelper->activeClub());
+            $countQb->where('e.club = :club')->setParameter('club', $this->clubHelper->activeClub());
+        }
+
+        $events = $listQb
             ->orderBy('e.startsAt', 'DESC')
             ->setFirstResult($offset)
             ->setMaxResults($limit)
             ->getQuery()
             ->getResult();
 
-        $totalEvents = $eventRepository->createQueryBuilder('e')
-            ->select('COUNT(e.id)')
-            ->where('e.club = :club')
-            ->setParameter('club', $this->clubHelper->activeClub())
-            ->getQuery()
-            ->getSingleScalarResult();
+        $totalEvents = $countQb->getQuery()->getSingleScalarResult();
 
         $totalPages = ceil($totalEvents / $limit);
 

--- a/src/Security/Voter/EventVoter.php
+++ b/src/Security/Voter/EventVoter.php
@@ -59,8 +59,8 @@ class EventVoter extends Voter
 
         // ... (check conditions and return true to grant permission) ...
         return match ($attribute) {
-            self::EDIT => $this->security->isGranted(UserRoleType::ADMIN, $user),
-            self::DELETE => $this->security->isGranted(UserRoleType::ADMIN, $user),
+            self::EDIT => $this->security->isGranted(UserRoleType::CLUB_ADMIN, $user),
+            self::DELETE => $this->security->isGranted(UserRoleType::CLUB_ADMIN, $user),
             self::VIEW => \in_array($event->getClub(), $clubs),
             default => false,
         };

--- a/src/Security/Voter/EventVoter.php
+++ b/src/Security/Voter/EventVoter.php
@@ -55,13 +55,16 @@ class EventVoter extends Voter
             $clubs[] = $licensee->getLicenseForSeason($eventSeason)?->getClub();
         }
 
-        array_filter($clubs);
+        $clubs = array_filter($clubs);
+
+        $isClubAdmin = $this->security->isGranted(UserRoleType::CLUB_ADMIN, $user);
+        $isAdmin = $this->security->isGranted(UserRoleType::ADMIN, $user);
+        $eventBelongsToUsersClub = \in_array($event->getClub(), $clubs, true);
 
         // ... (check conditions and return true to grant permission) ...
         return match ($attribute) {
-            self::EDIT => $this->security->isGranted(UserRoleType::CLUB_ADMIN, $user),
-            self::DELETE => $this->security->isGranted(UserRoleType::CLUB_ADMIN, $user),
-            self::VIEW => \in_array($event->getClub(), $clubs),
+            self::EDIT, self::DELETE => $isAdmin || ($isClubAdmin && $eventBelongsToUsersClub),
+            self::VIEW => $eventBelongsToUsersClub,
             default => false,
         };
     }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -171,13 +171,15 @@
                         </div>
                     </a>
                     <ul class="dropdown-menu" aria-labelledby="navbarScrollingDropdown">
-                        {% if (is_granted("ROLE_ADMIN")) %}
+                        {% if is_granted("ROLE_ADMIN") %}
                             <li>
                                 <a class="dropdown-item" href="{{ path('admin') }}">
                                     <em class="fa-solid fa-screwdriver-wrench"></em>
                                     Administration
                                 </a>
                             </li>
+                        {% endif %}
+                        {% if is_granted("ROLE_CLUB_ADMIN") %}
                             <li>
                                 <a class="dropdown-item" href="{{ path('app_event_manage_index') }}">
                                     <em class="fa-solid fa-calendar"></em>

--- a/templates/event/show_contest.html.twig
+++ b/templates/event/show_contest.html.twig
@@ -51,7 +51,7 @@
                     <i class="fa-solid fa-calendar-plus"></i>
                     Ajouter au calendrier
                 </a>
-                {% if is_granted('ROLE_CLUB_ADMIN') and not is_granted('ROLE_ADMIN') %}
+                {% if is_granted('ROLE_CLUB_ADMIN') %}
                 <a href="{{ path('app_event_manage_edit', {id: event.id}) }}" class="btn btn-outline-warning btn-sm me-2">
                     <i class="fa-solid fa-edit me-1"></i>
                     Modifier

--- a/templates/event/show_contest.html.twig
+++ b/templates/event/show_contest.html.twig
@@ -51,6 +51,12 @@
                     <i class="fa-solid fa-calendar-plus"></i>
                     Ajouter au calendrier
                 </a>
+                {% if is_granted('ROLE_CLUB_ADMIN') and not is_granted('ROLE_ADMIN') %}
+                <a href="{{ path('app_event_manage_edit', {id: event.id}) }}" class="btn btn-outline-warning btn-sm me-2">
+                    <i class="fa-solid fa-edit me-1"></i>
+                    Modifier
+                </a>
+                {% endif %}
                 {% if licenseeParticipation and licenseeParticipation.participationState == constant('App\\DBAL\\Types\\EventParticipationStateType::NOT_GOING') %}
                     {% set participationButtonLabel = 'Absent•e' %}
                     {% set participationButtonColor = 'danger' %}

--- a/templates/event/show_default.html.twig
+++ b/templates/event/show_default.html.twig
@@ -40,6 +40,12 @@
                     <i class="fa-solid fa-calendar-plus"></i>
                     Ajouter au calendrier
                 </a>
+                {% if is_granted('ROLE_CLUB_ADMIN') and not is_granted('ROLE_ADMIN') %}
+                <a href="{{ path('app_event_manage_edit', {id: event.id}) }}" class="btn btn-outline-warning btn-sm me-2">
+                    <i class="fa-solid fa-edit me-1"></i>
+                    Modifier
+                </a>
+                {% endif %}
                 {% if licenseeParticipation and licenseeParticipation.participationState == constant('App\\DBAL\\Types\\EventParticipationStateType::NOT_GOING') %}
                     {% set participationButtonLabel = 'Absent•e' %}
                     {% set participationButtonColor = 'danger' %}
@@ -83,7 +89,7 @@
         </div>
     </div>
 
-    {% if is_granted('ROLE_CLUB_ADMIN') %}
+    {% if is_granted('ROLE_ADMIN') %}
         <!-- Admin Section -->
         <div class="row mb-4">
             <div class="col-12">

--- a/templates/event/show_default.html.twig
+++ b/templates/event/show_default.html.twig
@@ -40,7 +40,7 @@
                     <i class="fa-solid fa-calendar-plus"></i>
                     Ajouter au calendrier
                 </a>
-                {% if is_granted('ROLE_CLUB_ADMIN') and not is_granted('ROLE_ADMIN') %}
+                {% if is_granted('ROLE_CLUB_ADMIN') %}
                 <a href="{{ path('app_event_manage_edit', {id: event.id}) }}" class="btn btn-outline-warning btn-sm me-2">
                     <i class="fa-solid fa-edit me-1"></i>
                     Modifier

--- a/templates/event/show_training.html.twig
+++ b/templates/event/show_training.html.twig
@@ -40,6 +40,12 @@
                     <i class="fa-solid fa-calendar-plus"></i>
                     Ajouter au calendrier
                 </a>
+                {% if is_granted('ROLE_CLUB_ADMIN') and not is_granted('ROLE_ADMIN') %}
+                <a href="{{ path('app_event_manage_edit', {id: event.id}) }}" class="btn btn-outline-warning btn-sm me-2">
+                    <i class="fa-solid fa-edit me-1"></i>
+                    Modifier
+                </a>
+                {% endif %}
                 {% if licenseeParticipation and licenseeParticipation.participationState == constant('App\\DBAL\\Types\\EventParticipationStateType::NOT_GOING') %}
                     {% set participationButtonLabel = 'Absent•e' %}
                     {% set participationButtonColor = 'danger' %}
@@ -83,7 +89,7 @@
         </div>
     </div>
 
-    {% if is_granted('ROLE_CLUB_ADMIN') %}
+    {% if is_granted('ROLE_ADMIN') %}
         <!-- Admin Section -->
         <div class="row mb-4">
             <div class="col-12">

--- a/templates/event/show_training.html.twig
+++ b/templates/event/show_training.html.twig
@@ -40,7 +40,7 @@
                     <i class="fa-solid fa-calendar-plus"></i>
                     Ajouter au calendrier
                 </a>
-                {% if is_granted('ROLE_CLUB_ADMIN') and not is_granted('ROLE_ADMIN') %}
+                {% if is_granted('ROLE_CLUB_ADMIN') %}
                 <a href="{{ path('app_event_manage_edit', {id: event.id}) }}" class="btn btn-outline-warning btn-sm me-2">
                     <i class="fa-solid fa-edit me-1"></i>
                     Modifier

--- a/tests/Functional/Controller/Management/EventManagementControllerTest.php
+++ b/tests/Functional/Controller/Management/EventManagementControllerTest.php
@@ -35,6 +35,58 @@ final class EventManagementControllerTest extends LoggedInTestCase
         $this->assertResponseIsSuccessful();
     }
 
+    public function testIndexRendersForClubAdmin(): void
+    {
+        $client = self::createLoggedInAsClubAdminClient();
+        $client->request(Request::METHOD_GET, self::URL_INDEX);
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testIndexAdminSeesEventsFromAllClubs(): void
+    {
+        // Create client first (required before container access)
+        $client = self::createLoggedInAsAdminClient();
+
+        /** @var EventRepository $eventRepo */
+        $eventRepo = self::getContainer()->get(EventRepository::class);
+        $totalEventsInDb = \count($eventRepo->findAll());
+
+        $client->request(Request::METHOD_GET, self::URL_INDEX);
+        $this->assertResponseIsSuccessful();
+
+        // Admin should have access to all events, not just their own club's
+        $ladgEventId = $this->getFirstLadgEventId();
+        $client->request(Request::METHOD_GET, \sprintf('/events/manage/%d/edit', $ladgEventId));
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testIndexClubAdminOnlySeesOwnClubEvents(): void
+    {
+        // Create client first (required before container access)
+        $client = self::createLoggedInAsClubAdminClient();
+
+        /** @var ClubRepository $clubRepo */
+        $clubRepo = self::getContainer()->get(ClubRepository::class);
+        $ladgClub = $clubRepo->findOneBy(['name' => 'Les Archers de Guyenne']);
+        $this->assertInstanceOf(Club::class, $ladgClub);
+
+        /** @var EventRepository $eventRepo */
+        $eventRepo = self::getContainer()->get(EventRepository::class);
+        $ladgEventCount = \count($eventRepo->findBy(['club' => $ladgClub]));
+        $totalEventCount = \count($eventRepo->findAll());
+
+        // Pre-condition: fixtures must have events from at least 2 clubs
+        $this->assertGreaterThan($ladgEventCount, $totalEventCount, 'Fixtures must include events from multiple clubs');
+
+        $crawler = $client->request(Request::METHOD_GET, self::URL_INDEX);
+        $this->assertResponseIsSuccessful();
+
+        // The "total events" count shown on the page should match only LADG events
+        $pageText = $crawler->text();
+        $this->assertStringContainsString((string) $ladgEventCount, $pageText);
+    }
+
     // ── Create (type selection) ────────────────────────────────────────
 
     public function testCreatePageRequiresClubAdmin(): void
@@ -145,6 +197,38 @@ final class EventManagementControllerTest extends LoggedInTestCase
         $this->assertSelectorExists('form');
     }
 
+    public function testEditFormShowsForClubAdminOwnClub(): void
+    {
+        $client = self::createLoggedInAsClubAdminClient();
+        $eventId = $this->getFirstLadgEventId();
+
+        $client->request(Request::METHOD_GET, \sprintf('/events/manage/%d/edit', $eventId));
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('form');
+    }
+
+    public function testClubAdminCannotEditOtherClubEvent(): void
+    {
+        $client = self::createLoggedInAsClubAdminClient();
+        $eventId = $this->getFirstLabdEventId(); // LADB event; club admin belongs to LADG
+
+        $client->request(Request::METHOD_GET, \sprintf('/events/manage/%d/edit', $eventId));
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testAdminCanEditEventFromAnyClub(): void
+    {
+        $client = self::createLoggedInAsAdminClient();
+        $eventId = $this->getFirstLadgEventId(); // LADG event; admin's licensee is in LADB
+
+        $client->request(Request::METHOD_GET, \sprintf('/events/manage/%d/edit', $eventId));
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('form');
+    }
+
     public function testEditFormSubmitSucceeds(): void
     {
         $client = self::createLoggedInAsAdminClient();
@@ -203,6 +287,18 @@ final class EventManagementControllerTest extends LoggedInTestCase
         $this->assertResponseRedirects();
     }
 
+    public function testClubAdminCannotDeleteOtherClubEvent(): void
+    {
+        $client = self::createLoggedInAsClubAdminClient();
+        $eventId = $this->getFirstLabdEventId(); // LADB event; club admin belongs to LADG
+
+        $client->request(Request::METHOD_POST, \sprintf('/events/manage/%d/delete', $eventId), [
+            '_token' => 'whatever',
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
     // ── Helper ────────────────────────────────────────────────────────
 
     private function getFirstLabdEventId(): int
@@ -216,6 +312,21 @@ final class EventManagementControllerTest extends LoggedInTestCase
         $eventRepo = self::getContainer()->get(EventRepository::class);
         $event = $eventRepo->findOneBy(['club' => $club]);
         $this->assertInstanceOf(Event::class, $event, 'No event found for club LADB');
+
+        return $event->getId();
+    }
+
+    private function getFirstLadgEventId(): int
+    {
+        /** @var ClubRepository $clubRepo */
+        $clubRepo = self::getContainer()->get(ClubRepository::class);
+        $club = $clubRepo->findOneBy(['name' => 'Les Archers de Guyenne']);
+        $this->assertInstanceOf(Club::class, $club, 'Club LADG not found in fixtures');
+
+        /** @var EventRepository $eventRepo */
+        $eventRepo = self::getContainer()->get(EventRepository::class);
+        $event = $eventRepo->findOneBy(['club' => $club]);
+        $this->assertInstanceOf(Event::class, $event, 'No event found for club LADG');
 
         return $event->getId();
     }

--- a/tests/Functional/Controller/Management/EventManagementControllerTest.php
+++ b/tests/Functional/Controller/Management/EventManagementControllerTest.php
@@ -48,10 +48,6 @@ final class EventManagementControllerTest extends LoggedInTestCase
         // Create client first (required before container access)
         $client = self::createLoggedInAsAdminClient();
 
-        /** @var EventRepository $eventRepo */
-        $eventRepo = self::getContainer()->get(EventRepository::class);
-        $totalEventsInDb = \count($eventRepo->findAll());
-
         $client->request(Request::METHOD_GET, self::URL_INDEX);
         $this->assertResponseIsSuccessful();
 


### PR DESCRIPTION
Fixes #115

## Changes

### `src/Security/Voter/EventVoter.php`
- `EDIT` and `DELETE` cases now check `ROLE_CLUB_ADMIN` instead of `ROLE_ADMIN` so club admins can manage their own club's events
- Added IDOR protection: club admins can only edit/delete events belonging to their own club (`$isAdmin || ($isClubAdmin && $eventBelongsToUsersClub)`)
- Fixed `array_filter()` result not being assigned back (Copilot review fix)
- `ROLE_ADMIN` inherits from `ROLE_CLUB_ADMIN` so full admins are unaffected

### `src/Controller/Management/EventManagementController.php`
- `index()` now scopes the event list to the club admin's own club; full `ROLE_ADMIN` users see all clubs' events (no filter)
- Injected `Security` service to distinguish `ROLE_ADMIN` from `ROLE_CLUB_ADMIN`

### `templates/base.html.twig`
- "Administration" (EasyAdmin) link remains `ROLE_ADMIN`-only
- "Gestion des évènements" split into its own `ROLE_CLUB_ADMIN` block so club admins can navigate to event management

### `templates/event/show_default.html.twig`, `show_training.html.twig`, `show_contest.html.twig`
- Yellow admin card (containing EasyAdmin links) restricted to `ROLE_ADMIN`
- "Modifier" button added in the hero section for all `ROLE_CLUB_ADMIN` users (including full admins)

### `docker/build/image_build.sh`
- Removed `ondrej/nginx` PPA (returned 403); image now uses Ubuntu's default nginx package

### `tests/Functional/Controller/Management/EventManagementControllerTest.php`
- Added `testIndexRendersForClubAdmin` — club admin can access the event management index
- Added `testIndexAdminSeesEventsFromAllClubs` — full admin can edit events from any club
- Added `testIndexClubAdminOnlySeesOwnClubEvents` — page count reflects only the club admin's club
- Added `testEditFormShowsForClubAdminOwnClub` — club admin can edit their own club's events (200)
- Added `testClubAdminCannotEditOtherClubEvent` — IDOR: club admin gets 403 on another club's event
- Added `testAdminCanEditEventFromAnyClub` — full admin can edit events from any club
- Added `testClubAdminCannotDeleteOtherClubEvent` — IDOR: club admin gets 403 on another club's delete
